### PR TITLE
Bugfix: `Worksheet.addSheetData` corrupting Xlsx file saved in Excel before

### DIFF
--- a/src/FSharpSpreadsheetML/WorkSheet.fs
+++ b/src/FSharpSpreadsheetML/WorkSheet.fs
@@ -12,7 +12,14 @@ module Worksheet =
 
     /// Associates a sheetData with the worksheet.
     let addSheetData (sheetData : SheetData) (worksheet : Worksheet) = 
-        worksheet.AppendChild sheetData |> ignore
+        let children = worksheet.ChildElements
+        let posPageMargins =
+            children
+            |> Seq.tryFindIndex (fun c -> c.LocalName = "pageMargins")
+        match posPageMargins with
+        | Some pos  -> worksheet.InsertAt(sheetData, pos)
+        | None      -> worksheet.AppendChild(sheetData)
+        |> ignore
         worksheet
 
     /// Returns true, if the worksheet contains sheetdata.

--- a/src/FSharpSpreadsheetML/WorkSheet.fs
+++ b/src/FSharpSpreadsheetML/WorkSheet.fs
@@ -41,7 +41,6 @@ module Worksheet =
             |> ignore
         addSheetData sheetData worksheet
 
-
     // Returns the Worksheet associated with the WorksheetPart.
     let get (worksheetPart : WorksheetPart) = 
         worksheetPart.Worksheet

--- a/src/FSharpSpreadsheetML/WorkSheet.fs
+++ b/src/FSharpSpreadsheetML/WorkSheet.fs
@@ -34,7 +34,12 @@ module Worksheet =
     let getSheetData (worksheet : Worksheet) = 
         worksheet.GetFirstChild<SheetData>()
       
-    //let setSheetData (sheetData:SheetData) (worksheet:Worksheet) = worksheet.sh
+    /// Sets the SheetData of a Worksheet.
+    let setSheetData (sheetData : SheetData) (worksheet : Worksheet) =
+        if hasSheetData worksheet then
+            worksheet.RemoveChild(getSheetData worksheet)
+            |> ignore
+        addSheetData sheetData worksheet
 
 
     // Returns the worksheet associated with the worksheetpart.

--- a/src/FSharpSpreadsheetML/WorkSheet.fs
+++ b/src/FSharpSpreadsheetML/WorkSheet.fs
@@ -10,7 +10,7 @@ module Worksheet =
     /// Empty Worksheet
     let empty() = Worksheet()
 
-    /// Associates a sheetData with the worksheet.
+    /// Associates a SheetData with the Worksheet.
     let addSheetData (sheetData : SheetData) (worksheet : Worksheet) = 
         let children = worksheet.ChildElements
         let posPageMargins =
@@ -22,15 +22,15 @@ module Worksheet =
         |> ignore
         worksheet
 
-    /// Returns true, if the worksheet contains sheetdata.
+    /// Returns true, if the Worksheet contains SheetData.
     let hasSheetData (worksheet : Worksheet) = 
         worksheet.HasChildren
 
-    /// Creates a worksheet containing the given sheetdata.
+    /// Creates a Worksheet containing the given SheetData.
     let ofSheetData (sheetData : SheetData) = 
         Worksheet(sheetData)
 
-    /// Returns the sheetdata associated with the worksheet.
+    /// Returns the sheetdata associated with the Worksheet.
     let getSheetData (worksheet : Worksheet) = 
         worksheet.GetFirstChild<SheetData>()
       
@@ -42,21 +42,21 @@ module Worksheet =
         addSheetData sheetData worksheet
 
 
-    // Returns the worksheet associated with the worksheetpart.
+    // Returns the Worksheet associated with the WorksheetPart.
     let get (worksheetPart : WorksheetPart) = 
         worksheetPart.Worksheet
 
-    /// Sets the given worksheet with the worksheetpart
+    /// Sets the given Worksheet with the WorksheetPart.
     let setWorksheet (worksheet : Worksheet) (worksheetPart : WorksheetPart) = 
         worksheetPart.Worksheet <- worksheet
         worksheetPart
 
-    /// Associates an empty worksheet with the worksheetpart.
+    /// Associates an empty Worksheet with the WworksheetPart.
     let init (worksheetPart : WorksheetPart) = 
         worksheetPart
         |> setWorksheet (empty())
 
-    /// Returns the existing or a newly created worksheet associated with the worksheetpart.
+    /// Returns the existing or a newly created Worksheet associated with the WorksheetPart.
     let getOrInit (worksheetPart : WorksheetPart) =
         if worksheetPart.Worksheet <> null then
             get worksheetPart
@@ -68,45 +68,45 @@ module Worksheet =
     /// Functions for extracting / working with WorksheetParts.
     module WorksheetPart = 
 
-        /// Returns the worksheetpart matching the given id.
+        /// Returns the WorksheetPart matching the given sheetID.
         let getByID sheetID (workbookPart : WorkbookPart) = 
             workbookPart.GetPartById(sheetID) :?> WorksheetPart  
             
-        /// Returns the sheetData associated with the worksheetpart.
+        /// Returns the SheetData associated with the WorksheetPart.
         let getSheetData (worksheetPart : WorksheetPart) =
             get worksheetPart |> getSheetData
 
-        /// Returns the worksheetCommentsPart associated with a worksheetPart.
+        /// Returns the WorksheetCommentsPart associated with a WorksheetPart.
         let getWorksheetCommentsPart (worksheetPart : WorksheetPart) = worksheetPart.WorksheetCommentsPart
 
     /// Functions for extracting / working with WorksheetCommentsParts.
     module WorksheetCommentsPart =
         
-        /// Returns the worksheetCommentsPart associated with a worksheetPart.
+        /// Returns the WorksheetCommentsPart associated with a WorksheetPart.
         let get (worksheetPart : WorksheetPart) = WorksheetPart.getWorksheetCommentsPart worksheetPart
         
-        /// Returns the comments of the worksheetCommentsPart.
+        /// Returns the comments of the WorksheetCommentsPart.
         let getComments (worksheetCommentsPart : WorksheetCommentsPart) = worksheetCommentsPart.Comments
 
     // TO DO: Atm. both types of comments (REAL comments and notes) are mixed. They seem to only differ in terms of their text: Comments have a disclaimer like "Comment:" or "Reply:" (the latter if it's a reply to a comment) while notes do not have that BUT have text formatting (can be seen in comments.xml in .xlsx archives))
     /// Functions for working with Comments.
     module Comments =
         
-        /// Returns the comments of the worksheetCommentsPart.
+        /// Returns the comments of the WorksheetCommentsPart.
         let get (worksheetCommentsPart : WorksheetCommentsPart) = worksheetCommentsPart.Comments
 
-        /// Returns the commentList of the given comments.
+        /// Returns the CommentList of the given Comments.
         let getCommentList (comments : Comments) = comments.CommentList
 
-        /// <summary>Returns a sequence of author names from the comments.</summary>
+        /// <summary>Returns a sequence of author names from the Comments.</summary>
         /// <remarks>Author names might be encrypted in the pattern of <code>tc={...}</code></remarks>
         let getAuthors (comments : Comments) = comments.Authors |> Seq.map (fun a -> a.InnerText)
 
-        /// Returns all comments and notes as strings of a commentList.
+        /// Returns all Comments and Notes as strings of a CommentList.
         let getCommentAndNoteTexts (commentList : CommentList) = 
             commentList |> Seq.map (fun c -> c.InnerText)
 
-        /// Returns a triple of comments consisting of the author, the comment text written, and the cell reference (A1-style).
+        /// Returns a triple of Comments consisting of the author, the comment text written, and the cell reference (A1-style).
         let getCommentsAuthorsTextsRefs (comments : Comments) =
             let authors = comments.Authors.Elements<DocumentFormat.OpenXml.Spreadsheet.Author>()
             let refsAuthorsTexts = 
@@ -124,7 +124,7 @@ module Worksheet =
                 )
             refsAuthorsTexts
 
-        /// Returns a triple of notes consisting of the author, the note text written, and the cell reference (A1-style).
+        /// Returns a triple of Notes consisting of the author, the note text written, and the cell reference (A1-style).
         let getNotesAuthorsTextsRefs (comments : Comments) =
             let authors = comments.Authors.Elements<DocumentFormat.OpenXml.Spreadsheet.Author>()
             let refsAuthorsTexts = 

--- a/src/FSharpSpreadsheetML/Workbook.fs
+++ b/src/FSharpSpreadsheetML/Workbook.fs
@@ -125,7 +125,7 @@ module WorkbookPart =
         workbookPart
 
     /// Replaces the SheetData of the Sheet with the given sheetname.
-    let replaceSheetData (sheetName : string) (data : SheetData) (workbookPart : WorkbookPart) =
+    let replaceSheetDataByName (sheetName : string) (data : SheetData) (workbookPart : WorkbookPart) =
 
         let workbook = Workbook.getOrInit  workbookPart
     

--- a/src/FSharpSpreadsheetML/Workbook.fs
+++ b/src/FSharpSpreadsheetML/Workbook.fs
@@ -3,25 +3,25 @@
 open DocumentFormat.OpenXml.Spreadsheet
 open DocumentFormat.OpenXml.Packaging
 
-/// Functions for manipulating workbooks. (Unmanaged: changing the sheets does not alter the associated worksheets which store the data)
+/// Functions for manipulating Workbooks. (Unmanaged: changing the sheets does not alter the associated worksheets which store the data)
 module Workbook =
 
-    /// Creates an empty workbook.
+    /// Creates an empty Workbook.
     let empty () = new Workbook()
     
-    /// Gets the workbook of the workbookPart.
+    /// Gets the Workbook of the WorkbookPart.
     let get (workbookPart : WorkbookPart) = workbookPart.Workbook 
 
-    /// Sets the workbook of the workbookPart.
+    /// Sets the Workbook of the WorkbookPart.
     let set (workbook : Workbook) (workbookPart : WorkbookPart) = 
         workbookPart.Workbook <- workbook
         workbookPart
 
-    /// Sets an empty workbook.
+    /// Sets an empty Workbook in the given WorkbookPart.
     let init (workbookPart : WorkbookPart) = 
         set (Workbook()) workbookPart
 
-    /// Returns the existing or a newly created workbook associated with the workbookpart.
+    /// Returns the Workbookpart associated with the existing or a newly created Workbook.
     let getOrInit (workbookPart : WorkbookPart) =
         if workbookPart.Workbook <> null then
             get workbookPart
@@ -39,45 +39,45 @@ module Workbook =
 /// Functions for working with WorkbookParts.
 module WorkbookPart = 
 
-    /// Add a worksheetPart to the workbookPart.
+    /// Add a WorksheetPart to the WorkbookPart.
     let addWorksheetPart (worksheetPart : WorksheetPart) (workbookPart : WorkbookPart) = 
         workbookPart.AddPart(worksheetPart)
 
-    /// Add an empty worksheetPart to the workbookPart.
+    /// Add an empty WorksheetPart to the WorkbookPart.
     let initWorksheetPart (workbookPart : WorkbookPart) = workbookPart.AddNewPart<WorksheetPart>()
 
-    /// Get the worksheetParts of the workbookPart.
+    /// Get the WorksheetParts of the WorkbookPart.
     let getWorkSheetParts (workbookPart : WorkbookPart) = workbookPart.WorksheetParts
 
-    /// Returns true if the workbookpart contains at least one worksheetPart.
+    /// Returns true if the WorkbookPart contains at least one WorksheetPart.
     let containsWorkSheetParts (workbookPart : WorkbookPart) = workbookPart.GetPartsOfType<WorksheetPart>() |> Seq.length |> (<>) 0
 
-    /// Gets the worksheetPart of the workbookPart with the given id.
+    /// Gets the WorksheetPart of the WorkbookPart with the given ID.
     let getWorksheetPartById (id : string) (workbookPart : WorkbookPart) = workbookPart.GetPartById(id) :?> WorksheetPart 
 
-    /// If the workbookpart contains the worksheetpart with the given id, returns it. Else returns None.
+    /// If the WorkbookPart contains the WorksheetPart with the given ID, returns it. Else returns None.
     let tryGetWorksheetPartById (id : string) (workbookPart : WorkbookPart) = 
         try workbookPart.GetPartById(id) :?> WorksheetPart  |> Some with
         | _ -> None
 
-    /// Gets the ID of the worksheetPart of the workbookPart.
+    /// Gets the ID of the WorksheetPart of the WorkbookPart.
     let getWorksheetPartID (worksheetPart : WorksheetPart) (workbookPart : WorkbookPart) = workbookPart.GetIdOfPart worksheetPart
     //let addworkSheet (workbookPart:WorkbookPart) (worksheet : Worksheet) = 
     //    let emptySheet = (addNewWorksheetPart workbookPart)
     //    emptySheet.Worksheet <- worksheet
 
-    /// Gets the sharedStringTablePart.
+    /// Gets the SharedStringTablePart of a WorkbookPart.
     let getSharedStringTablePart (workbookPart : WorkbookPart) = workbookPart.SharedStringTablePart
     
-    /// Sets an empty sharedStringTablePart.
+    /// Sets an empty SharedStringTablePart in the given WorkbookPart.
     let initSharedStringTablePart (workbookPart : WorkbookPart) = 
         workbookPart.AddNewPart<SharedStringTablePart>() |> ignore
         workbookPart
 
-    /// Returns true if the workbookPart contains a sharedStringTablePart.
+    /// Returns true if the WorkbookPart contains a SharedStringTablePart.
     let containsSharedStringTablePart (workbookPart : WorkbookPart) = workbookPart.SharedStringTablePart <> null
 
-    /// Returns the existing or a newly created sharedStringTablePart associated with the workbookPart.
+    /// Returns the existing or a newly created SharedStringTablePart associated with the WorkbookPart.
     let getOrInitSharedStringTablePart (workbookPart : WorkbookPart) =
         if containsSharedStringTablePart workbookPart then
             getSharedStringTablePart workbookPart
@@ -85,13 +85,13 @@ module WorkbookPart =
             initSharedStringTablePart workbookPart
             |> getSharedStringTablePart
     
-    /// Returns the sharedStringTable of a workbookPart.
+    /// Returns the SharedStringTable of a WorkbookPart.
     let getSharedStringTable (workbookPart : WorkbookPart) =
         workbookPart 
         |> getSharedStringTablePart 
         |> SharedStringTable.get
 
-    /// Returns the data of the first sheet of the given workbookPart.
+    /// Returns the SheetData of the first sheet of the given WorkbookPart.
     let getDataOfFirstSheet (workbookPart : WorkbookPart) = 
         workbookPart
         |> getWorkSheetParts
@@ -99,7 +99,7 @@ module WorkbookPart =
         |> Worksheet.get
         |> Worksheet.getSheetData
 
-    /// Appends a new sheet with the given sheet data to the MS Excel document.
+    /// Appends a new sheet with the given SheetData to the SpreadsheetDocument.
     // to-do: guard if sheet of name already exists
     let appendSheet (sheetName : string) (data : SheetData) (workbookPart : WorkbookPart) =
 
@@ -122,4 +122,22 @@ module WorkbookPart =
         let sheet = Sheet.create id sheetName sheetID
 
         sheets.AppendChild(sheet) |> ignore
+        workbookPart
+
+    /// Replaces the SheetData of the Sheet with the given sheetname.
+    let replaceSheetData (sheetName : string) (data : SheetData) (workbookPart : WorkbookPart) =
+
+        let workbook = Workbook.getOrInit  workbookPart
+    
+        let sheets = Sheet.Sheets.getOrInit workbook
+        let id = 
+            sheets |> Sheet.Sheets.getSheets
+            |> Seq.find (fun sheet -> Sheet.getName sheet = sheetName)
+            |> Sheet.getID
+
+        getWorksheetPartById id workbookPart
+        |> Worksheet.getOrInit
+        |> Worksheet.setSheetData data
+        |> ignore 
+
         workbookPart


### PR DESCRIPTION
- Fixes #16 
- Indirectly fixes https://github.com/nfdi4plants/ISADotNet/issues/49
- Adds `setSheetData` function
- Adds `replaceSheetData` function
- Some typos fixed, phrasing and wording unified